### PR TITLE
Bug 1451667 - Fix _store.push() call

### DIFF
--- a/pushsnapscript/snap_store.py
+++ b/pushsnapscript/snap_store.py
@@ -24,8 +24,12 @@ def push(context, snap_file_path, channel):
 
     macaroon_location = context.config['macaroons_locations'][channel]
     with _session(macaroon_location):
-        log.debug('Calling snapcraft push with these args: {}, {}'.format(snap_file_path, channel))
-        snapcraft_store_client.push(snap_file_path, channel)
+        push_kwargs = {
+            'snap_filename': snap_file_path,
+            'release_channels': [channel],
+        }
+        log.debug('Calling snapcraft push with these kwargs: {}'.format(push_kwargs))
+        snapcraft_store_client.push(**push_kwargs)
 
 
 @contextlib.contextmanager

--- a/pushsnapscript/test/integration/test_integration_script.py
+++ b/pushsnapscript/test/integration/test_integration_script.py
@@ -58,9 +58,9 @@ def test_script_can_push_snaps_with_credentials(event_loop, monkeypatch, channel
                 json.dump(config, config_file)
                 config_file.seek(0)
 
-                def snapcraft_store_client_push_fake(snap_file_path, channel):
-                    assert snap_file_path == snap_artifact_path
-                    assert channel == channel
+                def snapcraft_store_client_push_fake(snap_filename, release_channels):
+                    assert snap_filename == snap_artifact_path
+                    assert release_channels == [channel]
                     next(push_call_counter)
 
                 monkeypatch.setattr(snapcraft_store_client, 'push', snapcraft_store_client_push_fake)

--- a/pushsnapscript/test/test_snap_store.py
+++ b/pushsnapscript/test/test_snap_store.py
@@ -25,9 +25,9 @@ def test_push(monkeypatch, channel):
             assert config_fd.name == fake_macaroon.name
             next(login_call_count)
 
-        def snapcraft_store_client_push_fake(snap_file_path, channel):
-            assert snap_file_path == '/some/file.snap'
-            assert channel == channel
+        def snapcraft_store_client_push_fake(snap_filename, release_channels):
+            assert snap_filename == '/some/file.snap'
+            assert release_channels == [channel]
             next(push_call_count)
 
         monkeypatch.setattr(snapcraft_store_client, 'login', snapcraft_store_client_login_fake)


### PR DESCRIPTION
Context: https://bugs.launchpad.net/snapstore/+bug/1761488/comments/5.

kwargs names taken from: https://github.com/snapcore/snapcraft/blob/2.39.2/snapcraft/_store.py#L461 