### PR TITLE
Removes task schema from example config

### DIFF
--- a/examples/config.example.json
+++ b/examples/config.example.json
@@ -1,7 +1,6 @@
 {
   "work_dir": "/some/work/dir",
   "verbose": true,
-  "schema_file": "/path/to/pushsnapscript/data/push_snap_task_schema.json",
   "macaroons_locations": {
     "candidate": "/some/candidate_macaroon.cfg",
     "beta": "/some/beta_macaroon.cfg"


### PR DESCRIPTION
See [the related `scriptworker` bug](https://github.com/mozilla-releng/scriptworker/issues/287)